### PR TITLE
Fix filetypes

### DIFF
--- a/scripts/find_unused_icons.py
+++ b/scripts/find_unused_icons.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#
+# Script for listing unused icons in a plugin.
+
+import os
+import re
+import fnmatch
+
+ICON_USAGE_RE = re.compile(r"""IconLoader\.getIcon[ \t]*\([ \t]*(['"])/?((\\\1|.)*?)\1[ \t]*\)[ \t]*;""",
+                           flags=re.MULTILINE)
+
+
+def collect_file_recursively(path, pattern):
+    """
+    Method returns list of files in `path` that would match some `pattern`.
+    :param path: path for exploring.
+    :param pattern: pattern to match for.
+    :return: list of matches.
+    """
+    matches = list()
+    for root, folders, filenames in os.walk(path):
+        for filename in fnmatch.filter(filenames, pattern):
+            matches.append(os.path.join(root, filename))
+    return matches
+
+
+def collect_resource_icons(my_dir):
+    """
+    Method for searching existing icons in `resources` folder.
+    :param my_dir: folder of current script.
+    :return: set of found icons.
+    """
+    path = os.path.normpath(os.path.join(my_dir, os.path.pardir, 'resources'))
+
+    resource_icons = set()
+    for icon in collect_file_recursively(path, '*.png'):
+        if icon.endswith('@2x.png'):
+            continue
+        resource_icons.add(os.path.relpath(icon, path))
+
+    return resource_icons
+
+
+def collect_java_files(my_dir):
+    """
+    Method searches `*.java` files of a plugin.
+    :param my_dir: folder of current script.
+    :return: list of found java sources.
+    """
+    path = os.path.normpath(os.path.join(my_dir, os.path.pardir, 'src'))
+    return collect_file_recursively(path, '*.java')
+
+
+def find_icons_in_java(filename):
+    """
+    Method parses java file and searching usage of any icon resource in it.
+    :param filename: absolute path to java source file.
+    :return: list of used icons.
+    """
+    icons = list()
+    content = open(filename, 'rb').read()
+    for match in ICON_USAGE_RE.findall(content):
+        icons.append(match[1])
+    return icons
+
+
+def main(my_dir):
+    java_files = collect_java_files(my_dir)
+
+    # get icons, used in java source files
+    icon_usages = set()
+    for filename in java_files:
+        icon_usages = icon_usages.union(find_icons_in_java(filename))
+
+    # get existing icons
+    icons_in_resources = collect_resource_icons(my_dir)
+    # get missing files
+    unused = sorted(icons_in_resources - icon_usages)
+
+    if len(unused):
+        print('Here is icons, that are not used:')
+        for name in unused:
+            print("'{}' is not used!".format(name))
+
+
+if __name__ == '__main__':
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    main(current_dir)

--- a/src/com/widerwille/afterglow/AfterglowIcons.java
+++ b/src/com/widerwille/afterglow/AfterglowIcons.java
@@ -42,6 +42,8 @@ public class AfterglowIcons
 	public static final Icon JSON = IconLoader.getIcon("/file-icons/file_type_settings.png");
 	public static final Icon YAML = IconLoader.getIcon("/file-icons/file_type_yaml.png");
 	public static final Icon GRUNT = IconLoader.getIcon("/file-icons/file_type_gruntfile.png");
+	public static final Icon GULP = IconLoader.getIcon("/file-icons/file_type_gulpfile.png");
+	public static final Icon BOWER = IconLoader.getIcon("/file-icons/file_type_bower.png");
 	public static final Icon NPM = IconLoader.getIcon("/file-icons/file_type_npm.png");
 	public static final Icon BINARY = IconLoader.getIcon("/file-icons/file_type_binary.png");
 	public static final Icon TEXT = IconLoader.getIcon("/file-icons/file_type_text.png");
@@ -170,6 +172,8 @@ public class AfterglowIcons
 			case "json":
 				if(file.getName().equalsIgnoreCase("package.json"))
 					return NPM;
+				if(file.getName().equalsIgnoreCase("bower.json"))
+					return BOWER;
 
 				return JSON;
 			case "xml":
@@ -191,6 +195,8 @@ public class AfterglowIcons
 
 				if(file.getName().equalsIgnoreCase("gruntfile.js"))
 					return GRUNT;
+				if(file.getName().equalsIgnoreCase("gulpfile.js"))
+					return GULP;
 
 				return JAVASCRIPT;
 			case "coffeescript":


### PR DESCRIPTION
Hi!
You did a great job -- your plugin is just awesome! It's so quick and easy to setup it and without no configuration. Thank you, man :+1: 

But I found that  there is no support for some icons, although icons itself are presented in the repository. So I created a script, that shows which icons are not used, so you would know:

```
Here is icons, that are not used:
'file-icons/file_type_clojure.png' is not used!
'file-icons/file_type_docker.png' is not used!
'file-icons/file_type_elixir.png' is not used!
'file-icons/file_type_go.png' is not used!
'file-icons/file_type_lua.png' is not used!
'file-icons/file_type_mustache.png' is not used!
'file-icons/file_type_puppet.png' is not used!
'file-icons/file_type_rust.png' is not used!
'file-icons/file_type_scala.png' is not used!
'file-icons/file_type_tex.png' is not used!
```

And also I added  support for gulp and bower. 
